### PR TITLE
Add Bioconductor to CI

### DIFF
--- a/.github/workflows/standard-ci-workflow.yml
+++ b/.github/workflows/standard-ci-workflow.yml
@@ -61,9 +61,15 @@ jobs:
           sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
           sudo -s eval "$sysreqs"
 
+      - name: Install Bioconductor
+        run: |
+          install.packages("BiocManager")
+          BiocManager::install()
+        shell: Rscript {0}
+
       - name: Install dependencies
         run: |
-          remotes::install_deps(dependencies = TRUE)
+          remotes::install_deps(dependencies = TRUE, repos = BiocManager::repositories())
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 


### PR DESCRIPTION
This way all Bioconductor dependencies will be installed, without the need to add all those packages to `Remotes` as `bioc::pkgname`